### PR TITLE
Fix babel dependencies

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,6 @@
 {
-  "presets": [ "es2015" ],
+  "presets": [ "@spalger/babel-presets" ],
   "plugins": [
-    "add-module-exports",
-    "transform-async-functions",
-    "transform-runtime",
-    "transform-regenerator"
+    "add-module-exports"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/node-crypto",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Easy (yet strong) encryption and decryption facilities for Node.js",
   "main": "lib/crypto.js",
   "scripts": {
@@ -22,21 +22,16 @@
   "homepage": "https://github.com/elastic/node-crypto#readme",
   "devDependencies": {
     "@elastic/eslint-config-kibana": "0.2.0",
-    "babel-cli": "6.14.0",
-    "babel-core": "6.14.0",
+    "@spalger/babel-presets": "0.3.2",
+    "babel-cli": "6.16.0",
+    "babel-core": "6.17.0",
     "babel-eslint": "6.1.2",
     "babel-plugin-add-module-exports": "0.2.1",
-    "babel-plugin-transform-async-functions": "6.8.0",
-    "babel-plugin-transform-regenerator": "6.14.0",
-    "babel-plugin-transform-runtime": "6.15.0",
-    "babel-polyfill": "6.13.0",
-    "babel-preset-es2015": "6.14.0",
     "eslint": "3.4.0",
     "eslint-plugin-mocha": "4.5.1",
     "expect.js": "0.3.1",
     "mocha": "3.0.2",
     "nyc": "8.1.0",
-    "regenerator": "0.8.46",
     "retire": "1.2.10",
     "sinon": "1.17.5"
   }


### PR DESCRIPTION
Prior to this PR, running `npm run test:browser` in https://github.com/elastic/x-plugins/tree/master/kibana was resulting in this error: 

```
...
 log   [19:28:45.989] [fatal] Error: Cannot find module 'babel-runtime/helpers/slicedToArray'
...
```

@spalger helped me fix this with the changes in this PR.
