### PR TITLE
generic typing for crypto methods, key accepts Buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/node-crypto",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Easy (yet strong) encryption and decryption facilities for Node.js",
   "main": "lib/crypto.js",
   "types": "lib/crypto.d.ts",

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -25,9 +25,11 @@ export interface CryptoOptions {
   encryptionKey: string | Buffer;
 }
 
+export type EncryptOutput = string | object | number | boolean;
+
 export interface Crypto {
   encrypt<Input = any>(input: Input, aad?: string): Promise<string>;
-  decrypt<Output = any>(output: string | Buffer, aad?: string): Promise<Output>;
+  decrypt(encryptedOutput: string | Buffer, aad?: string): Promise<EncryptOutput | EncryptOutput[]>;
 }
 
 function _validateOpts({ encryptionKey }: CryptoOptions) {
@@ -124,11 +126,11 @@ export default function makeCryptoWith(opts: CryptoOptions): Crypto {
         return Buffer.concat([salt, iv, tag, encrypted]).toString(ENCRYPTION_RESULT_ENCODING);
       });
     },
-    async decrypt(output, aad) {
+    async decrypt(encryptedOutput, aad) {
       _validateAAD(aad);
-      const outputBytes = Buffer.isBuffer(output)
-        ? output
-        : Buffer.from(output, ENCRYPTION_RESULT_ENCODING);
+      const outputBytes = Buffer.isBuffer(encryptedOutput)
+        ? encryptedOutput
+        : Buffer.from(encryptedOutput, ENCRYPTION_RESULT_ENCODING);
 
       const salt = outputBytes.slice(0, SALT_LENGTH_IN_BYTES);
       const iv = outputBytes.slice(SALT_LENGTH_IN_BYTES, SALT_LENGTH_IN_BYTES + IV_LENGTH_IN_BYTES);

--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -22,14 +22,12 @@ const CIPHER_ALGORITHM = 'aes-256-gcm';
 const ENCRYPTION_RESULT_ENCODING = 'base64';
 
 export interface CryptoOptions {
-  encryptionKey: string;
+  encryptionKey: string | Buffer;
 }
 
-type EncryptInput = string | object | number | boolean;
-
 export interface Crypto {
-  encrypt(input: EncryptInput, aad?: string): Promise<string>;
-  decrypt(output: string | Buffer, aad?: string): Promise<EncryptInput>;
+  encrypt<Input = any>(input: Input, aad?: string): Promise<string>;
+  decrypt<Output = any>(output: string | Buffer, aad?: string): Promise<Output>;
 }
 
 function _validateOpts({ encryptionKey }: CryptoOptions) {


### PR DESCRIPTION
When integrating the types with kibana and our telemetry repo a generic made more sense than forcing `EncryptInput` type as output.

The config `encryptionKey` also accepts a `Buffer` not just a `string`.
