### PR TITLE
Added Synchronous apis for encrypt and decrypt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
     - "stable"
     - "10"
     - "8"
-    - "6"
 
 notifications:
     email: false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "editor.defaultFormatter": "vscode.typescript-language-features",
+    "editor.formatOnSave": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "editor.defaultFormatter": "vscode.typescript-language-features",
-    "editor.formatOnSave": true
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/node-crypto",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/node-crypto",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/node-crypto",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/node-crypto",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Easy (yet strong) encryption and decryption facilities for Node.js",
   "main": "lib/crypto.js",
   "types": "lib/crypto.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/node-crypto",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Easy (yet strong) encryption and decryption facilities for Node.js",
   "main": "lib/crypto.js",
   "types": "lib/crypto.d.ts",

--- a/src/crypto.test.ts
+++ b/src/crypto.test.ts
@@ -77,6 +77,58 @@ describe('crypto', () => {
     });
   });
 
+  describe('synchronous encrypt() and decrypt()', () => {
+    it('can handle strings', () => {
+      const testObj = 'I am a string';
+
+      const encrypted = crypto.encryptSync(testObj);
+      const decrypted = crypto.decryptSync(encrypted);
+
+      expect(decrypted).toEqual(testObj);
+    });
+
+    it('can handle numbers', () => {
+      const testObj = 234391265392819463321;
+
+      const encrypted = crypto.encryptSync(testObj);
+      const decrypted = crypto.decryptSync(encrypted);
+
+      expect(decrypted).toEqual(testObj);
+    });
+
+    it('can handle booleans', () => {
+      const testObj = false;
+
+      const encrypted = crypto.encryptSync(testObj);
+      const decrypted = crypto.decryptSync(encrypted);
+
+      expect(decrypted).toEqual(testObj);
+    });
+
+    it('can handle arrays', () => {
+      const testObj = [173, 'foo', false, { bar: 'baz' }];
+
+      const encrypted = crypto.encryptSync(testObj);
+      const decrypted = crypto.decryptSync(encrypted);
+
+      expect(decrypted).toEqual(testObj);
+    });
+
+    it('can handle objects', () => {
+      const testObj = {
+        aNumber: 17,
+        aString: 'baz',
+        anArray: [19, 23],
+        aBoolean: true,
+      };
+
+      const encrypted = crypto.encryptSync(testObj);
+      const decrypted = crypto.decryptSync(encrypted);
+
+      expect(decrypted).toEqual(testObj);
+    });
+  });
+
   describe('decrypt()', () => {
     it('fails when its input contains a modified salt', async () => {
       const testObj = 'I am a string';
@@ -126,6 +178,7 @@ describe('crypto', () => {
       );
     });
   });
+
 
   describe('backwards compatibility break test', () => {
     it('correctly decrypts a encrypted string literal', async () => {


### PR DESCRIPTION
As part of the work for Kibana Alerting, we need a synchronous way top interact with Encrypted Saved Objects (see https://github.com/elastic/kibana/issues/68994).

This PR adds two new entry points, `encryptSync` and `decryptSync` which are  identical to `encrypt` and `decrypt` but are synchronous.