### PR TITLE
Upgrade micromatch to 4.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4979,9 +4979,9 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean": "rm -rf lib coverage",
     "build": "npm run clean && tsc",
     "coverage": "jest --coverage",
-    "test": "retire -n -p package.json && npm run lint && npm run build && npm run unit",
+    "test": "npm audit && npm run lint && npm run build && npm run unit",
     "lint": "tslint -p tsconfig.json -c tslint.json",
     "unit": "jest"
   },


### PR DESCRIPTION
This PR updates the version of `micromatch` to 4.0.8

It also replaces the deprecated npm `retire` command with the npm `audit` command in the `test` script.